### PR TITLE
Add table view toggle to Bedrock Models Explorer

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -786,7 +786,10 @@ function renderModels() {
     const grid = document.getElementById('modelsGrid');
     const tableWrapper = document.getElementById('modelsTable');
 
-    if (currentView === 'table') {
+    // On mobile, always force card view
+    const isMobile = window.innerWidth <= 768;
+
+    if (currentView === 'table' && !isMobile) {
         grid.style.display = 'none';
         tableWrapper.style.display = 'block';
         renderTable();
@@ -812,58 +815,80 @@ function renderModels() {
         const modalityIcons = getModalityIcons(model);
         const streamingIcon = getStreamingIcon(model);
 
-        return `
-            <div class="model-card">
-                <div class="model-header">
-                    <div class="model-name">${formattedName}</div>
-                    <span class="badge ${badgeClass}">${provider}</span>
-                    <button class="copy-btn mobile-only" onclick="copyToClipboard('${model.id}')" title="Copy model ID">
-                        <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-                            <path d="M10.5 2H3.5C2.67157 2 2 2.67157 2 3.5V10.5C2 11.3284 2.67157 12 3.5 12H10.5C11.3284 12 12 11.3284 12 10.5V3.5C12 2.67157 11.3284 2 10.5 2Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-                            <path d="M14 5.5V12.5C14 13.3284 13.3284 14 12.5 14H5.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-                        </svg>
-                    </button>
-                </div>
-                
-                <div class="model-capabilities">
-                    ${modalityIcons}
-                </div>
-                
-                <div class="model-badges">
-                    ${crisTypes.map(type => {
+        const crisBadgesHtml = crisTypes.map(type => {
             const isDisabled = selectedRegion && !hasInferenceType(model, type, selectedRegion);
             const disabledClass = isDisabled ? 'badge-disabled' : '';
-            const clickHandler = isDisabled ? '' : `onclick="showRegionMap('${type}', '${model.id}', '${formattedName}')"`;
+            const clickHandler = isDisabled ? '' : `onclick="event.stopPropagation(); showRegionMap('${type}', '${model.id}', '${formattedName}')"`;
             const interactiveClass = isDisabled ? '' : 'badge-interactive';
             const titleAttr = isDisabled ? 'title="Not available in selected region"' : 'title="View Map"';
-
             return `<span class="badge badge-inference ${interactiveClass} ${disabledClass}" ${clickHandler} ${titleAttr}>${CRIS_REGIONS[type]}</span>`;
-        }).join('')}
-                    ${otherTypes.map(type => {
+        }).join('');
+
+        const otherBadgesHtml = otherTypes.map(type => {
             const isDisabled = selectedRegion && !hasInferenceType(model, type, selectedRegion);
             const disabledClass = isDisabled ? 'badge-disabled' : '';
             const titleAttr = isDisabled ? 'title="Not available in selected region"' : '';
             return `<span class="badge badge-inference ${disabledClass}" ${titleAttr}>${type !== 'ON_DEMAND' ? type.replace('_', ' ') : 'In Region'}</span>`;
-        }).join('')}
-                    <span class="badge ${model.model_lifecycle_status === 'ACTIVE' ? 'badge-active' : 'badge-legacy'}">
-                        ${model.model_lifecycle_status}
-                    </span>
+        }).join('');
+
+        const statusBadge = `<span class="badge ${model.model_lifecycle_status === 'ACTIVE' ? 'badge-active' : 'badge-legacy'}">${model.model_lifecycle_status}</span>`;
+
+        const copyBtnSvg = `<svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+            <path d="M10.5 2H3.5C2.67157 2 2 2.67157 2 3.5V10.5C2 11.3284 2.67157 12 3.5 12H10.5C11.3284 12 12 11.3284 12 10.5V3.5C12 2.67157 11.3284 2 10.5 2Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            <path d="M14 5.5V12.5C14 13.3284 13.3284 14 12.5 14H5.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>`;
+
+        const chevronSvg = `<svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+            <path d="M6 4L10 8L6 12" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>`;
+
+        return `
+            <div class="model-card" onclick="toggleMobileCard(this, event)">
+                <!-- Mobile compact view -->
+                <div class="mobile-compact">
+                    <div class="model-name">${formattedName}</div>
+                    <div class="model-capabilities">${modalityIcons}</div>
+                    <span class="mobile-expand-arrow">${chevronSvg}</span>
                 </div>
-                
-                <div class="model-id desktop-only">
+                <!-- Mobile expanded details -->
+                <div class="mobile-details">
+                    <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px;">
+                        <span class="badge ${badgeClass}">${provider}</span>
+                        ${statusBadge}
+                    </div>
+                    <div class="model-badges">${crisBadgesHtml}${otherBadgesHtml}</div>
+                    <div class="model-id">
+                        <span>${model.id}</span>
+                        <button class="copy-btn" onclick="event.stopPropagation(); copyToClipboard('${model.id}')" title="Copy model ID">${copyBtnSvg}</button>
+                    </div>
+                    <div class="model-section region-count-section" onclick="event.stopPropagation(); showAllRegions('${model.id}', '${formattedName}')" title="View all regions">
+                        <div class="section-title">
+                            <svg width="12" height="12" viewBox="0 0 16 16" fill="none" style="display:inline;vertical-align:middle;margin-right:4px;">
+                                <circle cx="8" cy="8" r="6" stroke="currentColor" stroke-width="1.5"/>
+                            </svg>
+                            <span>${model.regions.length} region${model.regions.length !== 1 ? 's' : ''}</span>
+                            <span class="info-hint"> (tap to view)</span>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Desktop full view -->
+                <div class="model-header">
+                    <div class="model-name">${formattedName}</div>
+                    <span class="badge ${badgeClass}">${provider}</span>
+                </div>
+                <div class="model-capabilities">${modalityIcons}</div>
+                <div class="model-badges">
+                    ${crisBadgesHtml}${otherBadgesHtml}
+                    ${statusBadge}
+                </div>
+                <div class="model-id">
                     <span>${model.id}</span>
-                    <button class="copy-btn" onclick="copyToClipboard('${model.id}')" title="Copy model ID">
-                        <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-                            <path d="M10.5 2H3.5C2.67157 2 2 2.67157 2 3.5V10.5C2 11.3284 2.67157 12 3.5 12H10.5C11.3284 12 12 11.3284 12 10.5V3.5C12 2.67157 11.3284 2 10.5 2Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-                            <path d="M14 5.5V12.5C14 13.3284 13.3284 14 12.5 14H5.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
-                        </svg>
-                    </button>
+                    <button class="copy-btn" onclick="event.stopPropagation(); copyToClipboard('${model.id}')" title="Copy model ID">${copyBtnSvg}</button>
                 </div>
-                
-                
-                <div class="model-section region-count-section" onclick="showAllRegions('${model.id}', '${formattedName}')" title="View all regions">
+                <div class="model-section region-count-section" onclick="event.stopPropagation(); showAllRegions('${model.id}', '${formattedName}')" title="View all regions">
                     <div class="section-title">
-                        <svg width="12" height="12" viewBox="0 0 16 16" fill="none" style="display: inline; vertical-align: middle; margin-right: 4px;">
+                        <svg width="12" height="12" viewBox="0 0 16 16" fill="none" style="display:inline;vertical-align:middle;margin-right:4px;">
                             <circle cx="8" cy="8" r="6" stroke="currentColor" stroke-width="1.5"/>
                         </svg>
                         <span>${model.regions.length} region${model.regions.length !== 1 ? 's' : ''}</span>
@@ -893,6 +918,23 @@ function getModalityIcons(model) {
 function getStreamingIcon(model) {
     return '';
 }
+
+function toggleMobileCard(card, event) {
+    // Only toggle on mobile
+    if (window.innerWidth > 768) return;
+    // Don't toggle if clicking interactive elements inside details
+    if (event.target.closest('.copy-btn, .badge-interactive, .region-count-section')) return;
+    card.classList.toggle('expanded');
+}
+
+// Re-render on resize to handle orientation changes
+let resizeTimer;
+window.addEventListener('resize', () => {
+    clearTimeout(resizeTimer);
+    resizeTimer = setTimeout(() => {
+        renderModels();
+    }, 250);
+});
 
 // Initialize on load
 init();

--- a/docs/app.js
+++ b/docs/app.js
@@ -74,9 +74,13 @@ function toggleTheme() {
 let selectedRegion = '';
 let selectedType = '';
 
+// View mode state
+let currentView = localStorage.getItem('viewMode') || 'grid';
+
 // Load and initialize
 async function init() {
     initTheme();
+    initViewToggle();
     try {
         const response = await fetch('bedrock_models.json');
         const data = await response.json();
@@ -708,8 +712,89 @@ function formatModelName(modelId) {
     return formatted;
 }
 
+function initViewToggle() {
+    const toggleBtns = document.querySelectorAll('.view-toggle-btn');
+    // Set initial active state from saved preference
+    toggleBtns.forEach(btn => {
+        btn.classList.toggle('active', btn.dataset.view === currentView);
+        btn.addEventListener('click', () => {
+            currentView = btn.dataset.view;
+            localStorage.setItem('viewMode', currentView);
+            toggleBtns.forEach(b => b.classList.toggle('active', b.dataset.view === currentView));
+            renderModels();
+        });
+    });
+}
+
+function renderTable() {
+    const tbody = document.getElementById('modelsTableBody');
+
+    if (filteredModels.length === 0) {
+        tbody.innerHTML = '<tr><td colspan="7" style="text-align:center;padding:40px;color:var(--text-secondary);">No models found matching your criteria.</td></tr>';
+        return;
+    }
+
+    tbody.innerHTML = filteredModels.map(model => {
+        const provider = getModelProvider(model.id);
+        const badgeClass = getBadgeClass(model.id);
+        const inferenceTypes = getInferenceTypes(model);
+        const crisTypes = inferenceTypes.filter(type => CRIS_REGIONS[type]);
+        const otherTypes = inferenceTypes.filter(type => !CRIS_REGIONS[type]);
+        const formattedName = formatModelName(model.id);
+        const modalityIcons = getModalityIcons(model);
+
+        const crisBadges = crisTypes.map(type => {
+            const isDisabled = selectedRegion && !hasInferenceType(model, type, selectedRegion);
+            const disabledClass = isDisabled ? 'badge-disabled' : '';
+            const clickHandler = isDisabled ? '' : `onclick="showRegionMap('${type}', '${model.id}', '${formattedName}')"`;
+            const interactiveClass = isDisabled ? '' : 'badge-interactive';
+            const titleAttr = isDisabled ? 'title="Not available in selected region"' : 'title="View Map"';
+            return `<span class="badge badge-inference ${interactiveClass} ${disabledClass}" ${clickHandler} ${titleAttr}>${CRIS_REGIONS[type]}</span>`;
+        }).join('');
+
+        const otherBadges = otherTypes.map(type => {
+            const isDisabled = selectedRegion && !hasInferenceType(model, type, selectedRegion);
+            const disabledClass = isDisabled ? 'badge-disabled' : '';
+            const titleAttr = isDisabled ? 'title="Not available in selected region"' : '';
+            return `<span class="badge badge-inference ${disabledClass}" ${titleAttr}>${type !== 'ON_DEMAND' ? type.replace('_', ' ') : 'In Region'}</span>`;
+        }).join('');
+
+        const statusClass = model.model_lifecycle_status === 'ACTIVE' ? 'badge-active' : 'badge-legacy';
+
+        return `
+            <tr>
+                <td class="table-model-name">${formattedName}</td>
+                <td><span class="badge ${badgeClass}">${provider}</span></td>
+                <td class="table-capabilities">${modalityIcons}</td>
+                <td class="table-inference">${crisBadges}${otherBadges}</td>
+                <td><span class="badge ${statusClass}">${model.model_lifecycle_status}</span></td>
+                <td><span class="table-region-count" onclick="showAllRegions('${model.id}', '${formattedName}')" title="View all regions">${model.regions.length} region${model.regions.length !== 1 ? 's' : ''}</span></td>
+                <td class="table-model-id">
+                    <code>${model.id}</code>
+                    <button class="copy-btn" onclick="copyToClipboard('${model.id}')" title="Copy model ID">
+                        <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+                            <path d="M10.5 2H3.5C2.67157 2 2 2.67157 2 3.5V10.5C2 11.3284 2.67157 12 3.5 12H10.5C11.3284 12 12 11.3284 12 10.5V3.5C12 2.67157 11.3284 2 10.5 2Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                            <path d="M14 5.5V12.5C14 13.3284 13.3284 14 12.5 14H5.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+                        </svg>
+                    </button>
+                </td>
+            </tr>`;
+    }).join('');
+}
+
 function renderModels() {
     const grid = document.getElementById('modelsGrid');
+    const tableWrapper = document.getElementById('modelsTable');
+
+    if (currentView === 'table') {
+        grid.style.display = 'none';
+        tableWrapper.style.display = 'block';
+        renderTable();
+        return;
+    }
+
+    grid.style.display = '';
+    tableWrapper.style.display = 'none';
 
     if (filteredModels.length === 0) {
         grid.innerHTML = '<p style="color: #666; grid-column: 1/-1; text-align: center; padding: 40px;">No models found matching your criteria.</p>';

--- a/docs/index.html
+++ b/docs/index.html
@@ -55,6 +55,22 @@
                 <input type="text" id="searchInput" placeholder="Search models...">
             </div>
 
+            <div class="view-toggle" id="viewToggle">
+                <button class="view-toggle-btn active" data-view="grid" title="Card view">
+                    <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+                        <rect x="1" y="1" width="6" height="6" rx="1" stroke="currentColor" stroke-width="1.5"/>
+                        <rect x="9" y="1" width="6" height="6" rx="1" stroke="currentColor" stroke-width="1.5"/>
+                        <rect x="1" y="9" width="6" height="6" rx="1" stroke="currentColor" stroke-width="1.5"/>
+                        <rect x="9" y="9" width="6" height="6" rx="1" stroke="currentColor" stroke-width="1.5"/>
+                    </svg>
+                </button>
+                <button class="view-toggle-btn" data-view="table" title="Table view">
+                    <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+                        <path d="M1 3H15M1 8H15M1 13H15" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+                    </svg>
+                </button>
+            </div>
+
             <div class="filters">
                 <div class="custom-select" id="regionFilterContainer">
                     <button class="select-button" id="regionButton">
@@ -103,6 +119,22 @@
         </div>
 
         <div id="modelsGrid" class="models-grid"></div>
+        <div id="modelsTable" class="models-table-wrapper" style="display:none;">
+            <table class="models-table">
+                <thead>
+                    <tr>
+                        <th>Model Name</th>
+                        <th>Provider</th>
+                        <th>Capabilities</th>
+                        <th>Inference</th>
+                        <th>Status</th>
+                        <th>Regions</th>
+                        <th>Model ID</th>
+                    </tr>
+                </thead>
+                <tbody id="modelsTableBody"></tbody>
+            </table>
+        </div>
     </div>
 
     <!-- Map Modal -->

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -42,6 +42,13 @@
     display: none !important;
 }
 
+/* Mobile card elements hidden on desktop */
+.mobile-compact,
+.mobile-details,
+.mobile-expand-arrow {
+    display: none;
+}
+
 @media (max-width: 768px) {
     .mobile-only {
         display: block !important;
@@ -49,6 +56,15 @@
 
     .desktop-only {
         display: none !important;
+    }
+
+    /* Show mobile card elements */
+    .mobile-compact {
+        display: flex !important;
+    }
+
+    .mobile-expand-arrow {
+        display: flex !important;
     }
 }
 
@@ -748,28 +764,99 @@ header {
 
     .filters {
         gap: 8px;
+        width: 100%;
     }
 
-    .custom-select {
-        min-width: 140px;
+    .filters .custom-select {
+        flex: 1;
+        min-width: 0;
     }
 
     .select-button {
         padding: 10px 12px;
     }
 
-    .models-grid {
-        grid-template-columns: 1fr;
-        gap: 12px;
+    /* Force card view on mobile, hide view toggle */
+    .view-toggle {
+        display: none;
     }
 
+    .models-grid {
+        grid-template-columns: 1fr;
+        gap: 8px;
+    }
+
+    /* Compact card on mobile */
     .model-card {
+        padding: 0;
+        cursor: pointer;
+    }
+
+    .model-card .mobile-compact {
+        display: flex;
+        align-items: center;
+        gap: 10px;
         padding: 12px;
     }
 
-    .model-name {
+    .model-card .mobile-compact .model-name {
         font-size: 14px;
-        margin-bottom: 4px;
+        flex: 1;
+        margin: 0;
+        padding-right: 0;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    .model-card .mobile-compact .model-name::after {
+        display: none;
+    }
+
+    .model-card .mobile-compact .model-capabilities {
+        margin: 0;
+        flex-shrink: 0;
+    }
+
+    .model-card .mobile-expand-arrow {
+        flex-shrink: 0;
+        color: var(--text-tertiary);
+        transition: transform 0.2s;
+        display: flex;
+        align-items: center;
+    }
+
+    .model-card.expanded .mobile-expand-arrow {
+        transform: rotate(90deg);
+    }
+
+    .model-card .mobile-details {
+        display: none;
+        padding: 0 12px 12px;
+        border-top: 1px solid var(--border-secondary);
+    }
+
+    .model-card.expanded .mobile-details {
+        display: block;
+    }
+
+    .model-card .mobile-details .model-badges {
+        margin-top: 10px;
+        margin-bottom: 10px;
+        gap: 6px;
+    }
+
+    .model-card .mobile-details .model-id {
+        margin-bottom: 10px;
+    }
+
+    /* Hide desktop card structure on mobile */
+    .model-card > .model-header,
+    .model-card > .model-capabilities,
+    .model-card > .model-badges,
+    .model-card > .model-id,
+    .model-card > .model-section {
+        display: none;
     }
 
     .model-header {
@@ -785,6 +872,11 @@ header {
     .model-badges {
         margin-bottom: 8px;
         gap: 6px;
+    }
+
+    .legend {
+        font-size: 11px;
+        gap: 8px;
     }
 }
 
@@ -1178,15 +1270,39 @@ header {
 }
 
 @media (max-width: 768px) {
+    /* Force card view on mobile - hide table entirely */
     .models-table-wrapper {
-        margin: 0 -12px;
-        border-radius: 0;
-        border-left: none;
-        border-right: none;
+        display: none !important;
+    }
+
+    .models-grid {
+        display: grid !important;
     }
 
     .view-toggle-btn {
         width: 38px;
+    }
+
+    /* Modal responsive */
+    .modal-content {
+        width: 95%;
+        max-height: 90vh;
+        overflow-y: auto;
+        padding: 16px;
+    }
+
+    #map {
+        height: 280px;
+    }
+
+    .modal-regions-list {
+        grid-template-columns: 1fr;
+    }
+
+    #modalTitle,
+    #regionsModalTitle {
+        font-size: 16px;
+        padding-right: 30px;
     }
 }
 

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1036,6 +1036,160 @@ header {
     }
 }
 
+/* View Toggle */
+.view-toggle {
+    display: flex;
+    border: 1.5px solid var(--input-border);
+    border-radius: 12px;
+    overflow: hidden;
+    flex-shrink: 0;
+    align-self: stretch;
+}
+
+.view-toggle-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    border: none;
+    background: var(--input-bg);
+    color: var(--text-tertiary);
+    cursor: pointer;
+    transition: all 0.2s;
+    padding: 0;
+}
+
+.view-toggle-btn:first-child {
+    border-right: 1px solid var(--input-border);
+}
+
+.view-toggle-btn:hover {
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+}
+
+.view-toggle-btn.active {
+    background: var(--bg-tertiary);
+    color: #0066cc;
+}
+
+[data-theme="dark"] .view-toggle-btn.active {
+    color: #5eb3ff;
+}
+
+/* Table View */
+.models-table-wrapper {
+    overflow-x: auto;
+    border: 1px solid var(--card-border);
+    border-radius: 8px;
+}
+
+.models-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 13px;
+}
+
+.models-table thead {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+}
+
+.models-table th {
+    background: var(--bg-tertiary);
+    color: var(--text-secondary);
+    font-weight: 600;
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    padding: 10px 12px;
+    text-align: left;
+    white-space: nowrap;
+    border-bottom: 2px solid var(--border-primary);
+}
+
+.models-table td {
+    padding: 10px 12px;
+    border-bottom: 1px solid var(--border-secondary);
+    vertical-align: middle;
+    color: var(--text-primary);
+}
+
+.models-table tbody tr:nth-child(even) {
+    background: var(--bg-tertiary);
+}
+
+.models-table tbody tr:hover {
+    background: var(--border-secondary);
+}
+
+.table-model-name {
+    font-weight: 600;
+    white-space: nowrap;
+}
+
+.table-capabilities {
+    white-space: nowrap;
+}
+
+.table-inference {
+    display: flex;
+    gap: 4px;
+    flex-wrap: wrap;
+}
+
+/* fix td display for inference column */
+.models-table td.table-inference {
+    display: flex;
+}
+
+.table-region-count {
+    color: #0066cc;
+    cursor: pointer;
+    font-weight: 500;
+    white-space: nowrap;
+}
+
+.table-region-count:hover {
+    text-decoration: underline;
+}
+
+[data-theme="dark"] .table-region-count {
+    color: #5eb3ff;
+}
+
+.table-model-id {
+    white-space: nowrap;
+}
+
+.table-model-id code {
+    font-family: 'Monaco', 'Menlo', 'Courier New', monospace;
+    font-size: 11px;
+    color: var(--text-secondary);
+    background: var(--bg-tertiary);
+    padding: 2px 6px;
+    border-radius: 3px;
+}
+
+.table-model-id .copy-btn {
+    margin-left: 6px;
+    vertical-align: middle;
+}
+
+@media (max-width: 768px) {
+    .models-table-wrapper {
+        margin: 0 -12px;
+        border-radius: 0;
+        border-left: none;
+        border-right: none;
+    }
+
+    .view-toggle-btn {
+        width: 38px;
+    }
+}
+
 /* Toast Notification */
 .toast {
     position: fixed;


### PR DESCRIPTION
Add a card/table view toggle so users can switch between the existing card grid and a tabular layout for easier scanning and comparison.

- Toggle button group (grid/table icons) in the controls bar
- Full table with columns: Model Name, Provider, Capabilities, Inference, Status, Regions, Model ID
- All card interactions work in table view (CRIS badge map modal, region count modal, copy model ID)

